### PR TITLE
Add models to store CKAN query configuration for a resource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "silverstripe/cms": "^4.3",
         "silverstripe/admin": "^1.3",
-        "silverstripe/vendor-plugin": "^1"
+        "silverstripe/vendor-plugin": "^1",
+        "symbiote/silverstripe-gridfieldextensions": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",

--- a/src/Model/Resource.php
+++ b/src/Model/Resource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Model;
+
+use SilverStripe\ORM\DataObject;
+
+/**
+ * A CKAN Resource that belongs to a DataSet/Package, as to be accessed via the CKAN API.
+ */
+class Resource extends DataObject
+{
+    private static $table_name = 'CKANResource';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'Endpoint' => 'Varchar',
+        'DataSet' => 'Varchar',
+        'Identifier' => 'Varchar',
+    ];
+
+    private static $has_many = [
+        'Fields' => ResourceField::class,
+        'Filters' => ResourceFilter::class,
+    ];
+
+    public function onAfterWrite()
+    {
+        if ($this->changed('Identifier')) {
+            $this->Fields()->removeAll();
+            $this->Filters()->removeAll();
+        }
+    }
+}

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Model;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\i18n\i18n;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBString;
+
+/**
+ * Represents a generic field on a CKAN Resource, e.g. a column in a spreadsheet.
+ * It is intentionally generic, as the resource may not be a tabular one, e.g. geospatal data to be rendered in a map.
+ */
+class ResourceField extends DataObject
+{
+    private static $table_name = 'CKANResourceField';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'Type' => 'Varchar',
+        'ReadableName' => 'Varchar',
+        'ShowInSummaryView' => 'Boolean',
+        'ShowInDetailView' => 'Boolean',
+        'RemoveDuplicates' => 'Boolean',
+        'Order' => 'Int',
+        'DisplayConditions' => 'Text',
+    ];
+
+    private static $has_one = [
+        'Resource' => Resource::class,
+    ];
+
+    private static $summary_fields = [
+        'Order',
+        'ReadableName',
+        'Name',
+        'Type',
+        'ShowInSummaryView',
+        'ShowInDetailView',
+    ];
+
+    /**
+     * Always display the 'ReadableName' unless it's unset, then display the name that is returned by CKAN
+     * @return string|DBString
+     */
+    public function getReadableName()
+    {
+        return $this->getField('ReadableName') ?: $this->Name;
+    }
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+
+        $fields->removeByName('Name');
+
+        $fields->removeByName('Type');
+        $fields->dataFieldByName('ReadableName')
+            ->setAttribute('placeholder', $this->Name);
+
+        $summary = $fields->dataFieldByName('ShowInSummaryView');
+        $detail = $fields->dataFieldByName('ShowInDetailView');
+        $duplicates = $fields->dataFieldByName('RemoveDuplicates');
+
+        $fields->removeByName(['ShowInSummaryView', 'ShowInDetailView', 'RemoveDuplicates',]);
+        $fields->insertBefore(FieldGroup::create('Visibility', [$summary, $detail, $duplicates]), 'Order');
+
+        $fields->removeByName('ResourceID');
+        return $fields;
+    }
+}

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Model;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\ListboxField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\i18n\i18n;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationResult;
+
+/**
+ * Represents a filter for a data resource, which accepts user inputted data and generates a query string (?key=value)
+ * to use in a request against a CKAN API for that particular resource in order to filter the results shown in a
+ * representation of that data.
+ */
+class ResourceFilter extends DataObject
+{
+    /**
+     * Types of FormFields that a filter could display as on the user facing side. Generally a list of
+     * {@see SilverStripe\Forms\FormField} mapped to human readable identifiers such as would be passed to a
+     * {@see DropDownField} as the source constructor parameter
+     *
+     * @config
+     * @var array
+     */
+    private static $filter_types = [
+        TextField::class => 'Text',
+        DropdownField::class => 'Select one from list',
+    ];
+
+    private static $table_name = 'CKANFilter';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'Type' => 'Varchar',
+        'AllFields' => 'Boolean',
+        'TypeOptions' => 'Text',
+    ];
+
+    private static $has_one = [
+        'FilterFor' => Resource::class,
+    ];
+
+    private static $many_many = [
+        'FilterFields' => ResourceField::class,
+    ];
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        $typeTitle = $fields->dataFieldByName('Type')->Title();
+        $fields->replaceField('Type', DropdownField::create(
+            'Type',
+            $typeTitle,
+            $this->config()->get('filter_types')
+        ));
+        $fields->replaceField('TypeOptions', HiddenField::create('TypeOptions'));
+        $fields->push(ListboxField::create(
+            'FilterFields',
+            'Columns to search',
+            $this->FilterFor()->Fields()->map('ID', 'ReadableName')
+        ));
+        $fields->removeByName('FilterForID');
+        return $fields;
+    }
+
+    public function forTemplate()
+    {
+        $options = json_decode($this->TypeOptions, true);
+        $field = Injector::inst()->createWithArgs($this->Type, $options);
+        if ($field instanceof FormField) {
+            throw new InvalidArgumentException("$this->Type is not a FormField");
+        }
+        return $field;
+    }
+}

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -4,7 +4,10 @@ namespace SilverStripe\CKANRegistry\Page;
 
 use Page;
 use SilverStripe\CKANRegistry\Forms\ResourceLocatorField;
+use SilverStripe\CKANRegistry\Model\Resource;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\TextField;
 
 /**
@@ -19,6 +22,10 @@ class CKANRegistryPage extends Page
         'ItemsPerPage' => 'Int',
     ];
 
+    private static $has_one = [
+        'DataResource' => Resource::class,
+    ];
+
     private static $defaults = [
         'ItemsPerPage' => 20,
     ];
@@ -29,8 +36,18 @@ class CKANRegistryPage extends Page
 
     public function getCMSFields()
     {
-        $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            $fields->addFieldToTab('Root.Data', ResourceLocatorField::create('Thing'));
+        $resource = $this->DataResource();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) use ($resource) {
+            $fields->addFieldToTab('Root.Data', ResourceLocatorField::create('DataSourceURL'));
+            if ($resource && $resource->Identifier) {
+                $columnsConfig = GridFieldConfig_RecordEditor::create();
+                $resourceFields = GridField::create('DataColumns', 'Columns', $resource->Fields(), $columnsConfig);
+                $fields->addFieldToTab('Root.Data', $resourceFields);
+
+                $filtersConfig = GridFieldConfig_RecordEditor::create();
+                $resourceFilters = GridField::create('DataFilters', 'Filters', $resource->Filters(), $filtersConfig);
+                $fields->addFieldToTab('Root.Filters', $resourceFilters);
+            }
         });
 
         return parent::getCMSFields();


### PR DESCRIPTION
In order to present data extracted from a CKAN resource, we'll need
to store the configuration to form a URI to request against the API.
This means we need data models, and a way to edit them in the CMS.