### PR TITLE
PHPDoc updates, beforeCMSFields implementation, add some tests

### DIFF
--- a/src/Model/Resource.php
+++ b/src/Model/Resource.php
@@ -3,9 +3,13 @@
 namespace SilverStripe\CKANRegistry\Model;
 
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
 
 /**
  * A CKAN Resource that belongs to a DataSet/Package, as to be accessed via the CKAN API.
+ *
+ * @method HasManyList Fields
+ * @method HasManyList Filters
  */
 class Resource extends DataObject
 {

--- a/src/Model/Resource.php
+++ b/src/Model/Resource.php
@@ -27,9 +27,14 @@ class Resource extends DataObject
         'Filters' => ResourceFilter::class,
     ];
 
+    /**
+     * Whenever the CKAN resource identifier is changed we should clear any existing field and filter configurations
+     *
+     * {@inheritdoc}
+     */
     public function onAfterWrite()
     {
-        if ($this->changed('Identifier')) {
+        if ($this->isChanged('Identifier')) {
             $this->Fields()->removeAll();
             $this->Filters()->removeAll();
         }

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -2,15 +2,16 @@
 
 namespace SilverStripe\CKANRegistry\Model;
 
-use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldGroup;
-use SilverStripe\i18n\i18n;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBString;
 
 /**
  * Represents a generic field on a CKAN Resource, e.g. a column in a spreadsheet.
  * It is intentionally generic, as the resource may not be a tabular one, e.g. geospatal data to be rendered in a map.
+ *
+ * @method Resource Resource
  */
 class ResourceField extends DataObject
 {

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -52,22 +52,22 @@ class ResourceField extends DataObject
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName('Name');
 
-        $fields->removeByName('Name');
+            $fields->removeByName('Type');
+            $fields->dataFieldByName('ReadableName')
+                ->setAttribute('placeholder', $this->Name);
 
-        $fields->removeByName('Type');
-        $fields->dataFieldByName('ReadableName')
-            ->setAttribute('placeholder', $this->Name);
+            $summary = $fields->dataFieldByName('ShowInSummaryView');
+            $detail = $fields->dataFieldByName('ShowInDetailView');
+            $duplicates = $fields->dataFieldByName('RemoveDuplicates');
 
-        $summary = $fields->dataFieldByName('ShowInSummaryView');
-        $detail = $fields->dataFieldByName('ShowInDetailView');
-        $duplicates = $fields->dataFieldByName('RemoveDuplicates');
+            $fields->removeByName(['ShowInSummaryView', 'ShowInDetailView', 'RemoveDuplicates',]);
+            $fields->insertBefore(FieldGroup::create('Visibility', [$summary, $detail, $duplicates]), 'Order');
 
-        $fields->removeByName(['ShowInSummaryView', 'ShowInDetailView', 'RemoveDuplicates',]);
-        $fields->insertBefore(FieldGroup::create('Visibility', [$summary, $detail, $duplicates]), 'Order');
-
-        $fields->removeByName('ResourceID');
-        return $fields;
+            $fields->removeByName('ResourceID');
+        });
+        return parent::getCMSFields();
     }
 }

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -41,15 +41,6 @@ class ResourceField extends DataObject
         'ShowInDetailView',
     ];
 
-    /**
-     * Always display the 'ReadableName' unless it's unset, then display the name that is returned by CKAN
-     * @return string|DBString
-     */
-    public function getReadableName()
-    {
-        return $this->getField('ReadableName') ?: $this->Name;
-    }
-
     public function getCMSFields()
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
@@ -69,5 +60,27 @@ class ResourceField extends DataObject
             $fields->removeByName('ResourceID');
         });
         return parent::getCMSFields();
+    }
+
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        if (empty($this->ReadableName) && !empty($this->Name)) {
+            $this->generateReadableName();
+        }
+    }
+
+    /**
+     * Generate a readable name from the Name
+     *
+     * @return $this
+     */
+    protected function generateReadableName()
+    {
+        $readableName = str_replace(['_', '-'], ' ', $this->Name);
+        $readableName = ucfirst(strtolower($readableName));
+        $this->ReadableName = $readableName;
+        return $this;
     }
 }

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -5,18 +5,21 @@ namespace SilverStripe\CKANRegistry\Model;
 use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\TextField;
-use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\ORM\ManyManyList;
 
 /**
  * Represents a filter for a data resource, which accepts user inputted data and generates a query string (?key=value)
  * to use in a request against a CKAN API for that particular resource in order to filter the results shown in a
  * representation of that data.
+ *
+ * @method Resource FilterFor
+ * @method ManyManyList FilterFields
  */
 class ResourceFilter extends DataObject
 {

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -55,21 +55,26 @@ class ResourceFilter extends DataObject
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-        $typeTitle = $fields->dataFieldByName('Type')->Title();
-        $fields->replaceField('Type', DropdownField::create(
-            'Type',
-            $typeTitle,
-            $this->config()->get('filter_types')
-        ));
-        $fields->replaceField('TypeOptions', HiddenField::create('TypeOptions'));
-        $fields->push(ListboxField::create(
-            'FilterFields',
-            'Columns to search',
-            $this->FilterFor()->Fields()->map('ID', 'ReadableName')
-        ));
-        $fields->removeByName('FilterForID');
-        return $fields;
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $typeTitle = $fields->dataFieldByName('Type')->Title();
+            $fields->replaceField('Type', DropdownField::create(
+                'Type',
+                $typeTitle,
+                $this->config()->get('filter_types')
+            ));
+
+            $fields->replaceField('TypeOptions', HiddenField::create('TypeOptions'));
+
+            $fields->push(ListboxField::create(
+                'FilterFields',
+                _t(__CLASS__ . '.ColumnsToSearch', 'Columns to search'),
+                $this->FilterFor()->Fields()->map('ID', 'ReadableName')
+            ));
+
+            $fields->removeByName('FilterForID');
+        });
+
+        return parent::getCMSFields();
     }
 
     public function forTemplate()

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -77,11 +77,16 @@ class ResourceFilter extends DataObject
         return parent::getCMSFields();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws InvalidArgumentException If the provided Type is not an instance of FormField
+     */
     public function forTemplate()
     {
         $options = json_decode($this->TypeOptions, true);
         $field = Injector::inst()->createWithArgs($this->Type, $options);
-        if ($field instanceof FormField) {
+        if (!$field instanceof FormField) {
             throw new InvalidArgumentException("$this->Type is not a FormField");
         }
         return $field;

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -13,6 +13,8 @@ use SilverStripe\Forms\TextField;
 /**
  * A CKANRegistryPage will render a chosen CKAN data set on the frontend, provide the user with configurable filters
  * and display a set of CMS configured columns.
+ *
+ * @method Resource DataResource
  */
 class CKANRegistryPage extends Page
 {

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -38,9 +38,10 @@ class CKANRegistryPage extends Page
 
     public function getCMSFields()
     {
-        $resource = $this->DataResource();
-        $this->beforeUpdateCMSFields(function (FieldList $fields) use ($resource) {
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $resource = $this->DataResource();
             $fields->addFieldToTab('Root.Data', ResourceLocatorField::create('DataSourceURL'));
+
             if ($resource && $resource->Identifier) {
                 $columnsConfig = GridFieldConfig_RecordEditor::create();
                 $resourceFields = GridField::create('DataColumns', 'Columns', $resource->Fields(), $columnsConfig);

--- a/tests/Model/ResourceFieldTest.php
+++ b/tests/Model/ResourceFieldTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Tests\Model;
+
+use SilverStripe\CKANRegistry\Model\ResourceField;
+use SilverStripe\Dev\SapphireTest;
+
+class ResourceFieldTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testReadableName()
+    {
+        $field = new ResourceField();
+        $field->Name = 'Teachers_In-mY-Country';
+        $field->write();
+
+        $this->assertSame(
+            'Teachers in my country',
+            $field->ReadableName,
+            'Readable name should be generated on write'
+        );
+
+        $field->Name = 'Some-new_Name';
+        $field->write();
+
+        $this->assertSame(
+            'Teachers in my country',
+            $field->ReadableName,
+            'Readable name should not be changed automatically once it is set'
+        );
+    }
+}

--- a/tests/Model/ResourceFilterTest.php
+++ b/tests/Model/ResourceFilterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Tests\Model;
+
+use InvalidArgumentException;
+use SilverStripe\CKANRegistry\Model\ResourceFilter;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Dev\SapphireTest;
+
+class ResourceFilterTest extends SapphireTest
+{
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage SilverStripe\Control\HTTPResponse is not a FormField
+     */
+    public function testForTemplateThrowsExceptionWithNonFormFieldType()
+    {
+        $filter = new ResourceFilter();
+        $filter->TypeOptions = '{}';
+        $filter->Type = 'SilverStripe\\Control\\HTTPResponse';
+        $filter->forTemplate();
+    }
+}

--- a/tests/Model/ResourceTest.php
+++ b/tests/Model/ResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Tests\Model;
+
+use SilverStripe\CKANRegistry\Model\Resource;
+use SilverStripe\Dev\SapphireTest;
+
+class ResourceTest extends SapphireTest
+{
+    protected static $fixture_file = 'ResourceTest.yml';
+
+    public function testFieldsAndFiltersAreRemovedAfterChangingIdentifier()
+    {
+        /** @var Resource $resource */
+        $resource = $this->objFromFixture(Resource::class, 'teachers');
+
+        $this->assertGreaterThan(0, $resource->Fields()->count(), 'Fixtures should load relationships');
+        $this->assertGreaterThan(0, $resource->Filters()->count(), 'Fixtures should load relationships');
+
+        // Change name, relationships should be retained
+        $resource->Name = 'Primary Teachers';
+        $resource->write();
+
+        $this->assertGreaterThan(0, $resource->Fields()->count(), 'Changing name should not affect relations');
+        $this->assertGreaterThan(0, $resource->Filters()->count(), 'Changing name should not affect relations');
+
+        // Change identifier, relationships should be removed
+        $resource->Identifier = 'something-different';
+        $resource->write();
+
+        $this->assertCount(0, $resource->Fields(), 'Changing identifier should clear fields');
+        $this->assertCount(0, $resource->Filters(), 'Changing identifier should clear filters');
+    }
+}

--- a/tests/Model/ResourceTest.yml
+++ b/tests/Model/ResourceTest.yml
@@ -1,0 +1,16 @@
+SilverStripe\CKANRegistry\Model\Resource:
+  teachers:
+    Name: Teachers
+    Endpoint: https://foo.ckan.gov/
+    DataSet: teachers
+    Identifier: 26f44973-b06d-479d-b697-8d7943c97c5a
+
+SilverStripe\CKANRegistry\Model\ResourceField:
+  subject:
+    Name: Subject
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+
+SilverStripe\CKANRegistry\Model\ResourceFilter:
+  city:
+    Name: City
+    FilterFor: =>SilverStripe\CKANRegistry\Model\Resource.teachers


### PR DESCRIPTION
Follow ups from https://github.com/silverstripe/silverstripe-ckan-registry/pull/36

Also adds some tests and moves the readable name generation logic into an onBeforeWrite() method