### PR TITLE
Ability to add filters, and configure them

### DIFF
--- a/src/Model/ResourceDropdownFilter.php
+++ b/src/Model/ResourceDropdownFilter.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CKANRegistry\Model;
 
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 
 class ResourceDropdownFilter extends ResourceFilter

--- a/src/Model/ResourceDropdownFilter.php
+++ b/src/Model/ResourceDropdownFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Model;
+
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\TextField;
+
+class ResourceDropdownFilter extends ResourceFilter
+{
+    private static $db = [
+        'Options' => 'Varchar'
+    ];
+
+    private static $singular_name = 'Dropdown Filter';
+
+    protected $fieldType = DropdownField::class;
+
+    public function getCMSFields()
+    {
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->push(TextField::create(
+                'Options',
+                _t(__CLASS__ . '.Options', 'Dropdown options')
+            ));
+
+            $fields->removeByName('FilterForID');
+        });
+
+        return parent::getCMSFields();
+    }
+}

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -21,7 +21,7 @@ use SilverStripe\ORM\ManyManyList;
  */
 class ResourceFilter extends DataObject
 {
-    private static $table_name = 'CKANFilter';
+    private static $table_name = 'CKANFilter_Text';
 
     private static $db = [
         'Name' => 'Varchar',
@@ -38,6 +38,12 @@ class ResourceFilter extends DataObject
 
     private static $singular_name = 'Text Filter';
 
+    /**
+     * Defines the type of {@link FormField} that will be used to render the filter in the CMS. This is defined
+     * in subclasses. Filters will render as TextFields by default.
+     *
+     * @var FormField
+     */
     protected $fieldType = TextField::class;
 
     public function getCMSFields()
@@ -62,7 +68,7 @@ class ResourceFilter extends DataObject
      */
     public function forTemplate()
     {
-        $field = Injector::inst()->createWithArgs($this->fieldType);
+        $field = Injector::inst()->createWithArgs($this->fieldType, []);
         if ($field instanceof FormField) {
             throw new InvalidArgumentException("$this->fieldType is not a FormField");
         }

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -4,10 +4,8 @@ namespace SilverStripe\CKANRegistry\Model;
 
 use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
-use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
@@ -23,26 +21,11 @@ use SilverStripe\ORM\ManyManyList;
  */
 class ResourceFilter extends DataObject
 {
-    /**
-     * Types of FormFields that a filter could display as on the user facing side. Generally a list of
-     * {@see SilverStripe\Forms\FormField} mapped to human readable identifiers such as would be passed to a
-     * {@see DropDownField} as the source constructor parameter
-     *
-     * @config
-     * @var array
-     */
-    private static $filter_types = [
-        TextField::class => 'Text',
-        DropdownField::class => 'Select one from list',
-    ];
-
     private static $table_name = 'CKANFilter';
 
     private static $db = [
         'Name' => 'Varchar',
-        'Type' => 'Varchar',
         'AllFields' => 'Boolean',
-        'TypeOptions' => 'Text',
     ];
 
     private static $has_one = [
@@ -53,18 +36,13 @@ class ResourceFilter extends DataObject
         'FilterFields' => ResourceField::class,
     ];
 
+    private static $singular_name = 'Text Filter';
+
+    protected $fieldType = TextField::class;
+
     public function getCMSFields()
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            $typeTitle = $fields->dataFieldByName('Type')->Title();
-            $fields->replaceField('Type', DropdownField::create(
-                'Type',
-                $typeTitle,
-                $this->config()->get('filter_types')
-            ));
-
-            $fields->replaceField('TypeOptions', HiddenField::create('TypeOptions'));
-
             $fields->push(ListboxField::create(
                 'FilterFields',
                 _t(__CLASS__ . '.ColumnsToSearch', 'Columns to search'),
@@ -84,10 +62,9 @@ class ResourceFilter extends DataObject
      */
     public function forTemplate()
     {
-        $options = json_decode($this->TypeOptions, true);
-        $field = Injector::inst()->createWithArgs($this->Type, $options);
-        if (!$field instanceof FormField) {
-            throw new InvalidArgumentException("$this->Type is not a FormField");
+        $field = Injector::inst()->createWithArgs($this->fieldType);
+        if ($field instanceof FormField) {
+            throw new InvalidArgumentException("$this->fieldType is not a FormField");
         }
         return $field;
     }

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -36,6 +36,11 @@ class ResourceFilter extends DataObject
         'FilterFields' => ResourceField::class,
     ];
 
+    private static $summary_fields = [
+        'Name',
+        'Type',
+    ];
+
     private static $singular_name = 'Text Filter';
 
     /**
@@ -73,5 +78,15 @@ class ResourceFilter extends DataObject
             throw new InvalidArgumentException("$this->fieldType is not a FormField");
         }
         return $field;
+    }
+
+    /**
+     * Returns the type of the filter, used for summary fields
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->singular_name();
     }
 }

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -68,8 +68,8 @@ class ResourceFilter extends DataObject
      */
     public function forTemplate()
     {
-        $field = Injector::inst()->createWithArgs($this->fieldType, []);
-        if ($field instanceof FormField) {
+        $field = Injector::inst()->createWithArgs($this->fieldType, [$this->Name]);
+        if (!$field instanceof FormField) {
             throw new InvalidArgumentException("$this->fieldType is not a FormField");
         }
         return $field;

--- a/src/Model/ResourceFilter/Dropdown.php
+++ b/src/Model/ResourceFilter/Dropdown.php
@@ -29,8 +29,6 @@ class Dropdown extends ResourceFilter
                 'Options',
                 _t(__CLASS__ . '.Options', 'Dropdown options')
             ));
-
-            $fields->removeByName('FilterForID');
         });
 
         return parent::getCMSFields();

--- a/src/Model/ResourceFilter/Dropdown.php
+++ b/src/Model/ResourceFilter/Dropdown.php
@@ -1,16 +1,22 @@
 <?php
 
-namespace SilverStripe\CKANRegistry\Model;
+namespace SilverStripe\CKANRegistry\Model\ResourceFilter;
 
+use SilverStripe\CKANRegistry\Model\ResourceFilter;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 
-class ResourceDropdownFilter extends ResourceFilter
+/**
+ * Provides a single select option for CKAN resources to be filtered by
+ */
+class Dropdown extends ResourceFilter
 {
     private static $db = [
-        'Options' => 'Varchar'
+        'Options' => 'Varchar',
     ];
+
+    private static $table_name = 'CKANFilter_Dropdown';
 
     private static $singular_name = 'Dropdown Filter';
 

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -5,10 +5,14 @@ namespace SilverStripe\CKANRegistry\Page;
 use Page;
 use SilverStripe\CKANRegistry\Forms\ResourceLocatorField;
 use SilverStripe\CKANRegistry\Model\Resource;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\TextField;
+use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
 
 /**
  * A CKANRegistryPage will render a chosen CKAN data set on the frontend, provide the user with configurable filters
@@ -48,6 +52,11 @@ class CKANRegistryPage extends Page
                 $fields->addFieldToTab('Root.Data', $resourceFields);
 
                 $filtersConfig = GridFieldConfig_RecordEditor::create();
+                $filtersConfig->removeComponentsByType([
+                    GridFieldAddExistingAutocompleter::class,
+                    GridFieldAddNewButton::class
+                ])
+                    ->addComponent(Injector::inst()->create(GridFieldAddNewMultiClass::class));
                 $resourceFilters = GridField::create('DataFilters', 'Filters', $resource->Filters(), $filtersConfig);
                 $fields->addFieldToTab('Root.Filters', $resourceFilters);
             }

--- a/tests/Model/ResourceFilter/DropdownTest.php
+++ b/tests/Model/ResourceFilter/DropdownTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Tests\Model\ResourceFilter;
+
+use SilverStripe\CKANRegistry\Model\ResourceFilter\Dropdown;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\TextField;
+
+class DropdownTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testGetCMSFields()
+    {
+        $field = new Dropdown();
+        $fields = $field->getCMSFields();
+
+        $this->assertInstanceOf(
+            TextField::class,
+            $fields->dataFieldByName('Options'),
+            'Options field should exist'
+        );
+    }
+
+    public function testGetType()
+    {
+        $field = new Dropdown();
+        $this->assertSame('Dropdown Filter', $field->getType());
+    }
+}

--- a/tests/Model/ResourceFilterTest.php
+++ b/tests/Model/ResourceFilterTest.php
@@ -3,10 +3,13 @@
 namespace SilverStripe\CKANRegistry\Tests\Model;
 
 use InvalidArgumentException;
+use SilverStripe\CKANRegistry\Model\ResourceFilter;
 use SilverStripe\Dev\SapphireTest;
 
 class ResourceFilterTest extends SapphireTest
 {
+    protected $usesDatabase = true;
+
     /**
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage SilverStripe\Control\HTTPResponse is not a FormField
@@ -15,5 +18,19 @@ class ResourceFilterTest extends SapphireTest
     {
         $filter = new ResourceFilterTest\InvalidResourceFilter();
         $filter->forTemplate();
+    }
+
+    public function testGetType()
+    {
+        $filter = new ResourceFilter();
+        $this->assertSame('Text Filter', $filter->getType());
+    }
+
+    public function testGetCMSFields()
+    {
+        $filter = new ResourceFilter();
+        $fields = $filter->getCMSFields();
+
+        $this->assertNull($fields->dataFieldByName('FilterForID'), 'FilterForID should be removed');
     }
 }

--- a/tests/Model/ResourceFilterTest.php
+++ b/tests/Model/ResourceFilterTest.php
@@ -3,8 +3,6 @@
 namespace SilverStripe\CKANRegistry\Tests\Model;
 
 use InvalidArgumentException;
-use SilverStripe\CKANRegistry\Model\ResourceFilter;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Dev\SapphireTest;
 
 class ResourceFilterTest extends SapphireTest
@@ -15,9 +13,7 @@ class ResourceFilterTest extends SapphireTest
      */
     public function testForTemplateThrowsExceptionWithNonFormFieldType()
     {
-        $filter = new ResourceFilter();
-        $filter->TypeOptions = '{}';
-        $filter->Type = 'SilverStripe\\Control\\HTTPResponse';
+        $filter = new ResourceFilterTest\InvalidResourceFilter();
         $filter->forTemplate();
     }
 }

--- a/tests/Model/ResourceFilterTest/InvalidResourceFilter.php
+++ b/tests/Model/ResourceFilterTest/InvalidResourceFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Tests\Model\ResourceFilterTest;
+
+use SilverStripe\CKANRegistry\Model\ResourceFilter;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * Represents an invalid {@link ResourceFilter} implementation, used for testing error handling
+ */
+class InvalidResourceFilter extends ResourceFilter implements TestOnly
+{
+    protected $fieldType = HTTPResponse::class;
+}


### PR DESCRIPTION
Data is loaded into the resource (field info, etc), at which point an
administrator can then configure search filters for them that users can
operate on the 'front end' in order to refine the resource's data being
loaded. This commit adds the CMS interface for administering thes
filters.

Resolves #28