### PR TITLE
NEW add the ability to reorder resource filters

### DIFF
--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -26,6 +26,7 @@ class ResourceFilter extends DataObject
     private static $db = [
         'Name' => 'Varchar',
         'AllFields' => 'Boolean',
+        'Order' => 'Int',
     ];
 
     private static $has_one = [

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\TextField;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 /**
  * A CKANRegistryPage will render a chosen CKAN data set on the frontend, provide the user with configurable filters
@@ -47,7 +48,10 @@ class CKANRegistryPage extends Page
             $fields->addFieldToTab('Root.Data', ResourceLocatorField::create('DataResource'));
 
             if ($resource && $resource->Identifier) {
-                $columnsConfig = GridFieldConfig_RecordEditor::create();
+                $injector = Injector::inst();
+
+                $columnsConfig = GridFieldConfig_RecordEditor::create()
+                    ->addComponent($injector->createWithArgs(GridFieldOrderableRows::class, ['Order']));
                 $resourceFields = GridField::create('DataColumns', 'Columns', $resource->Fields(), $columnsConfig);
                 $fields->addFieldToTab('Root.Data', $resourceFields);
 
@@ -56,7 +60,10 @@ class CKANRegistryPage extends Page
                     GridFieldAddExistingAutocompleter::class,
                     GridFieldAddNewButton::class
                 ])
-                    ->addComponent(Injector::inst()->create(GridFieldAddNewMultiClass::class));
+                    ->addComponents([
+                        $injector->create(GridFieldAddNewMultiClass::class),
+                        $injector->createWithArgs(GridFieldOrderableRows::class, ['Order']),
+                    ]);
                 $resourceFilters = GridField::create('DataFilters', 'Filters', $resource->Filters(), $filtersConfig);
                 $fields->addFieldToTab('Root.Filters', $resourceFilters);
             }


### PR DESCRIPTION
Which will allow content authors (people administering the resource
display configuration) to provide pre-defined ways for users to search
the data returned by the CKAN resource, and the way in which they
present to the user if there are more than one.

closes #24 