### PR TITLE
NEW Have a default filter to search all fields

### DIFF
--- a/src/Model/Resource.php
+++ b/src/Model/Resource.php
@@ -43,7 +43,10 @@ class Resource extends DataObject
         if ($this->isChanged('Identifier')) {
             $this->Fields()->removeAll();
             Injector::inst()->get(ResourceFieldPopulatorInterface::class)->populateFields($this);
-            $this->Filters()->removeAll();
+            // Remove the existing filters and add a default text entry to search all ResourceFields
+            $this->Filters()->removeAll()
+                ->add(ResourceFilter::create());
         }
+        parent::onAfterWrite();
     }
 }

--- a/tests/Model/ResourceTest.php
+++ b/tests/Model/ResourceTest.php
@@ -40,6 +40,10 @@ class ResourceTest extends SapphireTest
         $resource->write();
 
         $this->assertCount(0, $resource->Fields(), 'Changing identifier should clear fields');
-        $this->assertCount(0, $resource->Filters(), 'Changing identifier should clear filters');
+        $this->assertCount(
+            1,
+            $resource->Filters(),
+            'Changing identifier should clear filters (note that a default filter is added again as well)'
+        );
     }
 }


### PR DESCRIPTION
When adding a resource, also add a default filter for searching all
fields on the resource. This eases the setup of a searchable registry.

closes #27 