### PR TITLE
Make translation key format consistent throughout code base

### DIFF
--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -57,7 +57,7 @@ class ResourceFilter extends DataObject
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $fields->push(ListboxField::create(
                 'FilterFields',
-                _t(__CLASS__ . '.ColumnsToSearch', 'Columns to search'),
+                _t(__CLASS__ . '.COLUMNS_TO_SEARCH', 'Columns to search'),
                 $this->FilterFor()->Fields()->map('ID', 'ReadableName')
             ));
 

--- a/src/Model/ResourceFilter/Dropdown.php
+++ b/src/Model/ResourceFilter/Dropdown.php
@@ -27,7 +27,7 @@ class Dropdown extends ResourceFilter
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $fields->push(TextField::create(
                 'Options',
-                _t(__CLASS__ . '.Options', 'Dropdown options')
+                _t(__CLASS__ . '.OPTIONS', 'Dropdown options')
             ));
         });
 

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -77,7 +77,7 @@ class CKANRegistryPage extends Page
         $fields = parent::getSettingsFields();
 
         $fields->addFieldsToTab('Root.Settings', [
-            TextField::create('ItemsPerPage', _t(__CLASS__ . '.ItemsPerPage', 'Items per page')),
+            TextField::create('ItemsPerPage', _t(__CLASS__ . '.ITEMS_PER_PAGE', 'Items per page')),
         ]);
 
         return $fields;


### PR DESCRIPTION
Instead of a mixture of CamelCase and SNAKE_CASE, we can reduce
cognitive load in maintenance.