### PR TITLE
API Rename ShowInSummaryView, relabel Presented Order, consolidate label lowercasing

### DIFF
--- a/client/lang/src/en.json
+++ b/client/lang/src/en.json
@@ -1,7 +1,5 @@
 {
-  "CKANResourceLocator.DATA_SOURCE_URL": "Data source URL",
-  "CKANResourceLocator.INVALID_DATASET_URL": "The provided data source URL does not appear to be a valid CKAN data set.",
-  "CKANResourceLocator.INVALID_RESOURCE_SELECTION": "Datastore is not available for the selected resource.",
-  "CKANResultConditions.MUST_MATCH": "Must match",
-  "CKANResultConditions.MUST_NOT_MATCH": "Must not match"
+  "CKANResourceLocatorField.DATA_SOURCE_URL": "Data source URL",
+  "CKANResourceLocatorField.INVALID_DATASET_URL": "The provided data source URL does not appear to be a valid CKAN data set.",
+  "CKANResourceLocatorField.INVALID_RESOURCE_SELECTION": "Datastore is not available for the selected resource."
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,8 +1,50 @@
 en:
+  SilverStripe\CKANRegistry\Forms\ResourceLocatorField:
+    DESCRIPTION: 'Connect to a data source from {site}. Once added and saved you can configure the appearance and add search filters.'
+    GENERIC_SITE_NAME: 'a CKAN website'
+  SilverStripe\CKANRegistry\Forms\ResultConditionsField:
+    MUST_MATCH: 'Must match'
+    MUST_NOT_MATCH: 'Must not match'
+  SilverStripe\CKANRegistry\Model\Resource:
+    PLURALNAME: Resources
+    PLURALS:
+      one: 'A Resource'
+      other: '{count} Resources'
+    SINGULARNAME: Resource
+  SilverStripe\CKANRegistry\Model\ResourceField:
+    ORDER_DENOMINATOR: 'of {count} columns'
+    ORDER_LABEL: 'Presented order'
+    ORIGINAL_LABEL_DESCRIPTION: 'Title of this field as provided by the CKAN resource'
+    PLURALNAME: 'Resource Fields'
+    PLURALS:
+      one: 'A Resource Field'
+      other: '{count} Resource Fields'
+    REMOVE_DUPLICATES_LABEL: 'Only show one value if duplicates exist'
+    RESULT_CONDITIONS: 'Result conditions'
+    SINGULARNAME: 'Resource Field'
+  SilverStripe\CKANRegistry\Model\ResourceFilter:
+    ALL_COLUMNS: 'All columns'
+    COLUMNS_SOURCES: 'Columns source(s)'
+    MULTIPLE_COLUMNS: 'Multiple columns'
+    PLURALNAME: Texts
+    PLURALS:
+      one: 'A Text'
+      other: '{count} Texts'
+    SINGULARNAME: Text
+  SilverStripe\CKANRegistry\Model\ResourceFilter\Dropdown:
+    OPTIONS: 'Dropdown options'
+    PLURALNAME: Dropdowns
+    PLURALS:
+      one: 'A Dropdown'
+      other: '{count} Dropdowns'
+    SINGULARNAME: Dropdown
   SilverStripe\CKANRegistry\Page\CKANRegistryPage:
-    ItemsPerPage: 'Items per page'
+    IN_DETAIL: 'In Detail'
+    IN_RESULTS: 'In Results'
+    ITEMS_PER_PAGE: 'Items per page'
     PLURALNAME: 'CKAN Registry Pages'
     PLURALS:
       one: 'A CKAN Registry Page'
       other: '{count} CKAN Registry Pages'
+    POS: Pos.
     SINGULARNAME: 'CKAN Registry Page'

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -48,7 +48,7 @@ class ResourceFilter extends DataObject
         'Columns',
     ];
 
-    private static $singular_name = 'Text Filter';
+    private static $singular_name = 'Text';
 
     /**
      * Defines the type of {@link FormField} that will be used to render the filter in the CMS. This is defined

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -63,8 +63,6 @@ class ResourceFilter extends DataObject
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $allColumnsField = $fields->dataFieldByName('AllColumns');
             $allColumnsField->addExtraClass('ckan-columns__all-columns');
-            // See https://github.com/silverstripe/silverstripe-framework/issues/8696
-            $allColumnsField->setTitle(ucfirst(strtolower($allColumnsField->Title())));
 
             // Remove the scaffolded Filter Fields tab and the AllColumns field
             $fields->removeByName(['FilterFields', 'AllColumns']);
@@ -83,11 +81,16 @@ class ResourceFilter extends DataObject
                 ->addExtraClass('ckan-columns__sources');
             $fields->push($columnSources);
 
-            // See https://github.com/silverstripe/silverstripe-framework/issues/8696
-            $filterLabel = $fields->dataFieldByName('FilterLabel');
-            $filterLabel->setTitle(ucfirst(strtolower($filterLabel->Title())));
+            $fields->removeByName([
+                'FilterForID',
+                'Order',
+            ]);
 
-            $fields->removeByName('FilterForID');
+            // See https://github.com/silverstripe/silverstripe-framework/issues/8696
+            foreach (['AllColumns', 'FilterLabel'] as $fieldName) {
+                $field = $fields->dataFieldByName($fieldName);
+                $field->setTitle(ucfirst(strtolower($field->Title())));
+            }
         });
 
         return parent::getCMSFields();

--- a/src/Model/ResourceFilter/Dropdown.php
+++ b/src/Model/ResourceFilter/Dropdown.php
@@ -18,7 +18,7 @@ class Dropdown extends ResourceFilter
 
     private static $table_name = 'CKANFilter_Dropdown';
 
-    private static $singular_name = 'Dropdown Filter';
+    private static $singular_name = 'Dropdown';
 
     protected $fieldType = DropdownField::class;
 

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -96,7 +96,7 @@ class CKANRegistryPage extends Page
                         $injector->createWithArgs(GridFieldOrderableRows::class, ['Order']),
                     ]);
 
-                $resourceFilters = GridField::create('DataFilters', 'Filters', $resource->Filters(), $filtersConfig);
+                $resourceFilters = GridField::create('DataFilters', '', $resource->Filters(), $filtersConfig);
 
                 $fields->addFieldToTab('Root.Filters', $resourceFilters);
             }

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -71,13 +71,13 @@ class CKANRegistryPage extends Page
                         $columns = $component->getDisplayFields($resourceFields);
 
                         // We only want to change the labels for the GridField view, not the model's edit form
-                        $columns['ShowInSummaryView'] = _t(__CLASS__ . '.IN_RESULTS', 'In Results');
+                        $columns['ShowInResultsView'] = _t(__CLASS__ . '.IN_RESULTS', 'In Results');
                         $columns['ShowInDetailView'] = _t(__CLASS__ . '.IN_DETAIL', 'In Detail');
 
                         // Abbreviate the position title
                         $columns['Position'] = _t(__CLASS__ . '.POS', 'Pos.', 'Abbreviated version of position');
 
-                        $editable = array_flip(['ShowInSummaryView', 'ShowInDetailView']);
+                        $editable = array_flip(['ShowInResultsView', 'ShowInDetailView']);
                         $component->setDisplayFields(array_diff_key($columns, $editable));
                         // set this way so that title translations are preserved
                         $editableColumns->setDisplayFields(array_intersect_key($columns, $editable));

--- a/tests/Model/ResourceFilter/DropdownTest.php
+++ b/tests/Model/ResourceFilter/DropdownTest.php
@@ -25,6 +25,6 @@ class DropdownTest extends SapphireTest
     public function testGetType()
     {
         $field = new Dropdown();
-        $this->assertSame('Dropdown Filter', $field->getType());
+        $this->assertSame('Dropdown', $field->getType());
     }
 }

--- a/tests/Model/ResourceFilterTest.php
+++ b/tests/Model/ResourceFilterTest.php
@@ -24,7 +24,7 @@ class ResourceFilterTest extends SapphireTest
     public function testGetType()
     {
         $filter = new ResourceFilter();
-        $this->assertSame('Text Filter', $filter->getType());
+        $this->assertSame('Text', $filter->getType());
     }
 
     public function testGetCMSFields()

--- a/tests/Page/CKANRegistryPageTest.php
+++ b/tests/Page/CKANRegistryPageTest.php
@@ -76,7 +76,7 @@ class CKANRegistryPageTest extends SapphireTest
 
         $displayFields = $component->getDisplayFields($field);
         $this->assertEquals([
-            'ShowInSummaryView' => _t('SilverStripe\\CKANRegistry\\Page\\CKANRegistryPage.IN_RESULTS', 'In Results'),
+            'ShowInResultsView' => _t('SilverStripe\\CKANRegistry\\Page\\CKANRegistryPage.IN_RESULTS', 'In Results'),
             'ShowInDetailView' => _t('SilverStripe\\CKANRegistry\\Page\\CKANRegistryPage.IN_DETAIL', 'In Detail'),
         ], $displayFields, 'Correct display fields were not found');
     }


### PR DESCRIPTION
Other changes:

* Remove "Order" field in filter CMS fields
* Consolidate lowercase label logic so it can be easily removed once SS 4.4 is the minimum
* Remove unneeded "Filters" GridField header in filter CMS fields
* Remove "Filter" from filter type labels (now just Text and Dropdown)
* Update translation sources

Resolves #85