### PR TITLE
FIX when no data is set, show the ResourceLocatorField by default

### DIFF
--- a/templates/SilverStripe/CKANRegistry/Forms/ResourceLocatorField_holder.ss
+++ b/templates/SilverStripe/CKANRegistry/Forms/ResourceLocatorField_holder.ss
@@ -1,9 +1,9 @@
 <%--
-    Note: GridFieldResourceTitle allows toggling of visibility, use "hide" to hide it initially. Also note
-    that we do this in the field holder template to ensure that the "hide" class isn't propagated down to
-    the actual form field itself - same with the container class.
+    Note: GridFieldResourceTitle allows toggling of visibility, use "hide" to hide it initially if there is a value set
+    Also note that we do this in the field holder template to ensure that the "hide" class isn't propagated down to the
+    actual form field itself - same with the container class.
 --%>
-<div $getAttributesHTML('class', 'value') data-schema="$SchemaData.JSON" class="hide ckan-resource-locator__container $ExtraClass">
+<div $getAttributesHTML('class', 'value') data-schema="$SchemaData.JSON" class="<% if $Value %>hide <% end_if %>ckan-resource-locator__container $ExtraClass">
     <%-- Field is rendered by React components --%>
     <input type="hidden" name="$Name" value="$Value.JSON" />
 </div>


### PR DESCRIPTION
The 'nomrmally hidden' status of the ResourceLocatorField is good,
but only when a resource has already been chosen and its columns
loaded. In the case that one has not been saved, the "Data" tab on
a Page loads empty. So in order to allow people to enter data and
save the columns initially, we need to show the field.