### PR TITLE
FIX Updating GridFieldDetailForm saving of ResourceFields to not create invalid ordering when updating the order field

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\CKANRegistry\Forms\GridField\GridFieldDetailForm;
+
+use SilverStripe\CKANRegistry\Model\ResourceField;
+use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
+use SilverStripe\ORM\Queries\SQLUpdate;
+
+class ResourceFieldItemRequest extends GridFieldDetailForm_ItemRequest
+{
+    protected function saveFormIntoRecord($data, $form)
+    {
+        // Update the record so that we can investigate the changes
+        $form->saveInto($this->record);
+        $changes = $this->record->getChangedFields();
+
+        // Delegate to the parent now to do the save
+        /** @var ResourceField $record */
+        $record = parent::saveFormIntoRecord($data, $form);
+
+        // Continue out if the sort order has not changed
+        if (!isset($changes['Position'])) {
+            return $record;
+        }
+
+        $change = $changes['Position'];
+        $oldPosition = (int) $change['before'];
+        $newPosition = (int) $change['after'];
+
+        if ($oldPosition === $newPosition) {
+            return $record;
+        }
+
+        // Otherwise we might need to update the position of other columns belonging to the resource
+        $resource = $record->Resource;
+
+
+        // If we've moved up the list that means other records need to move down
+        $operator = $newPosition < $oldPosition ? '+' : '-';
+
+        // Now we just need to target all objects between the new and old positions
+        if ($newPosition < $oldPosition) {
+            $where = [
+                '"Position" >= ?' => $newPosition,
+                '"Position" < ?' => $oldPosition,
+            ];
+        } else {
+            $where = [
+                '"Position" > ?' => $oldPosition,
+                '"Position" <= ?' => $newPosition,
+            ];
+        }
+
+        $update = SQLUpdate::create(
+            $record->baseTable(),
+            [],
+            $where + ['"ID" != ?' => $record->ID, '"ResourceID"' => $resource->ID]
+        );
+
+        $update->assignSQL("\"Position\"", "\"Position\" $operator 1");
+
+        $update->execute();
+
+        return $record;
+    }
+}

--- a/src/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CKANRegistry\Forms\GridField\GridFieldDetailForm;
 
 use SilverStripe\CKANRegistry\Model\ResourceField;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
 use SilverStripe\ORM\Queries\SQLUpdate;
 
@@ -52,7 +53,7 @@ class ResourceFieldItemRequest extends GridFieldDetailForm_ItemRequest
         }
 
         $update = SQLUpdate::create(
-            $record->baseTable(),
+            '"' . $record->baseTable() . '"',
             [],
             $where + ['"ID" != ?' => $record->ID, '"ResourceID"' => $resource->ID]
         );

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -13,7 +13,7 @@ use SilverStripe\ORM\DataObject;
  * Represents a generic field on a CKAN Resource, e.g. a column in a spreadsheet.
  * It is intentionally generic, as the resource may not be a tabular one, e.g. geospatial data to be rendered in a map.
  *
- * @method Resource Resource
+ * @property Resource Resource
  * @method static ResourceField create()
  * @property string OriginalLabel
  * @property string Type

--- a/src/Page/CKANRegistryPage.php
+++ b/src/Page/CKANRegistryPage.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CKANRegistry\Page;
 
 use Page;
+use SilverStripe\CKANRegistry\Forms\GridField\GridFieldDetailForm\ResourceFieldItemRequest;
 use SilverStripe\CKANRegistry\Forms\GridFieldResourceTitle;
 use SilverStripe\CKANRegistry\Forms\ResourceLocatorField;
 use SilverStripe\CKANRegistry\Model\Resource;
@@ -14,6 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\TextField;
@@ -72,6 +74,9 @@ class CKANRegistryPage extends Page
                         GridFieldPageCount::class,
                         GridFieldToolbarHeader::class,
                     ]);
+
+                $columnsConfig->getComponentByType(GridFieldDetailForm::class)
+                    ->setItemRequestClass(ResourceFieldItemRequest::class);
 
                 $resourceFields = GridField::create('DataColumns', '', $resource->Fields(), $columnsConfig);
                 $resourceFields->addExtraClass('ckan-columns');

--- a/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.yml
+++ b/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequest.yml
@@ -1,0 +1,32 @@
+SilverStripe\CKANRegistry\Model\Resource:
+  teachers:
+    Name: Teachers
+    Endpoint: https://foo.ckan.gov/
+    DataSet: teachers
+    Identifier: 26f44973-b06d-479d-b697-8d7943c97c5a
+
+SilverStripe\CKANRegistry\Model\ResourceField:
+  firstname:
+    OriginalLabel: "First name"
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 1
+  lastname:
+    OriginalLabel: "Last name"
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 2
+  subject:
+    OriginalLabel: Subject
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 3
+  city:
+    OriginalLabel: City
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 4
+  school:
+    OriginalLabel: School
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 5
+  gender:
+    OriginalLabel: Gender
+    Resource: =>SilverStripe\CKANRegistry\Model\Resource.teachers
+    Position: 6

--- a/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
+++ b/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
@@ -40,7 +40,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
         /** @var Resource $resource */
         $resource = $this->objFromFixture(Resource::class, 'teachers');
 
-        $this->assertSame(
+        $this->assertArrayEqualsInOrder(
             [
                 'Subject' => '1',
                 'First name' => '2',
@@ -54,7 +54,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
         $this->moveFieldFixture('firstname', 5);
 
-        $this->assertSame(
+        $this->assertArrayEqualsInOrder(
             [
                 'Subject' => '1',
                 'Last name' => '2',
@@ -68,7 +68,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
         $this->moveFieldFixture('subject', 9);
 
-        $this->assertSame(
+        $this->assertArrayEqualsInOrder(
             [
                 'Last name' => '1',
                 'City' => '2',
@@ -82,7 +82,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
         $this->moveFieldFixture('gender', 1);
 
-        $this->assertSame(
+        $this->assertArrayEqualsInOrder(
             [
                 'Gender' => '1',
                 'Last name' => '2',
@@ -134,5 +134,20 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
         // Handle our request
         $itemRequest->handleRequest($request);
+    }
+
+    protected function assertArrayEqualsInOrder($expected, $actual)
+    {
+        $message = 'Failed asserting array in order. Expected '.print_r($expected, true).
+            '. Actual: '.print_r($actual, true);
+
+        foreach ($actual as $key => $value) {
+            $expectedKey = key($expected);
+            $expectedValue = array_shift($expected);
+            $this->assertSame($expectedKey, $key, $message);
+            $this->assertEquals($expectedValue, $value, $message);
+        }
+
+        $this->assertEmpty($expected, $message);
     }
 }

--- a/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
+++ b/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
@@ -1,0 +1,138 @@
+<?php
+namespace SilverStripe\CKANRegistry\Tests\Forms\GridField\GridFieldDetailForm;
+
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\CKANRegistry\Forms\GridField\GridFieldDetailForm\ResourceFieldItemRequest;
+use SilverStripe\CKANRegistry\Model\Resource;
+use SilverStripe\CKANRegistry\Model\ResourceField;
+use SilverStripe\CKANRegistry\Page\CKANRegistryPage;
+use SilverStripe\CKANRegistry\Service\ResourcePopulator;
+use SilverStripe\CKANRegistry\Service\ResourcePopulatorInterface;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Security\SecurityToken;
+
+class ResourceFieldItemRequestTest extends SapphireTest
+{
+    protected static $fixture_file = 'ResourceFieldItemRequest.yml';
+
+    protected function setUp()
+    {
+        $populator = $this->createMock(ResourcePopulator::class);
+        Injector::inst()->registerService($populator, ResourcePopulatorInterface::class);
+
+        $populator->method('populateFields')->willReturnSelf();
+        $populator->method('populateMetadata')->willReturnSelf();
+
+        parent::setUp();
+    }
+
+    public function testSortingOnResourceSave()
+    {
+        $this->moveFieldFixture('subject', 1);
+
+        /** @var Resource $resource */
+        $resource = $this->objFromFixture(Resource::class, 'teachers');
+
+        $this->assertSame(
+            [
+                'Subject' => '1',
+                'First name' => '2',
+                'Last name' => '3',
+                'City' => '4',
+                'School' => '5',
+                'Gender' => '6',
+            ],
+            $resource->Fields()->sort('Position', 'ASC')->map('OriginalLabel', 'Position')->toArray()
+        );
+
+        $this->moveFieldFixture('firstname', 5);
+
+        $this->assertSame(
+            [
+                'Subject' => '1',
+                'Last name' => '2',
+                'City' => '3',
+                'School' => '4',
+                'First name' => '5',
+                'Gender' => '6',
+            ],
+            $resource->Fields()->sort('Position', 'ASC')->map('OriginalLabel', 'Position')->toArray()
+        );
+
+        $this->moveFieldFixture('subject', 9);
+
+        $this->assertSame(
+            [
+                'Last name' => '1',
+                'City' => '2',
+                'School' => '3',
+                'First name' => '4',
+                'Gender' => '5',
+                'Subject' => '9',
+            ],
+            $resource->Fields()->sort('Position', 'ASC')->map('OriginalLabel', 'Position')->toArray()
+        );
+
+        $this->moveFieldFixture('gender', 1);
+
+        $this->assertSame(
+            [
+                'Gender' => '1',
+                'Last name' => '2',
+                'City' => '3',
+                'School' => '4',
+                'First name' => '5',
+                'Subject' => '9',
+            ],
+            $resource->Fields()->sort('Position', 'ASC')->map('OriginalLabel', 'Position')->toArray()
+        );
+    }
+
+    protected function moveFieldFixture($fixture, $newPosition)
+    {
+        // Locate the resource fixture and the specified fixture
+        /** @var Resource $resource */
+        $resource = $this->objFromFixture(Resource::class, 'teachers');
+        $field = $this->objFromFixture(ResourceField::class, $fixture);
+
+        // Form a request
+        $token = SecurityToken::create();
+        $request = new HTTPRequest('POST', 'ItemEditForm', [], [
+            'Position' => $newPosition,
+            'action_doSave' => 1,
+            $token->getName() => $token->getValue(),
+        ]);
+        $request->setSession(Controller::curr()->getRequest()->getSession());
+
+        // Build the gridfield and component
+        $config = GridFieldConfig::create();
+        $detailForm = new GridFieldDetailForm;
+        $config->addComponent($detailForm->setItemRequestClass(ResourceFieldItemRequest::class));
+        $gridField = new GridField('Test', 'Test', $resource->Fields(), $config);
+        $formMock = $this->createMock(Form::class);
+        $formMock->method('FormAction')->willReturn('test');
+        $gridField->setForm($formMock);
+        $controllerMock = $this->createMock(Controller::class);
+        $controllerMock->method('Link')->willReturn('test');
+        $controllerMock->method('getRequest')->willReturn($request);
+
+        // Create an item request
+        $itemRequest = new ResourceFieldItemRequest(
+            $gridField,
+            $detailForm,
+            $field,
+            $controllerMock,
+            'Test'
+        );
+
+        // Handle our request
+        $itemRequest->handleRequest($request);
+    }
+}


### PR DESCRIPTION
WIP because I need to add some tests but the functionality is ready for a peer review and test. It'd be nice for someone to check this out and play with it a bit because I was trying to get this done before bug day was over :laughing:

This overloads the save handler for ResourceField so that we can implement our own logic that updates other ResourceField after a sort order is updated. I chose this over creating an extension because an extension would apply to all GridFieldDetailForm's.

Fixes #98