### PR TITLE
DOCS change dev docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ composer require silverstripe/ckan-registry 1.0.x-dev
 
 ## Documentation
 
-Developer documentation [is available in the "docs" directory](docs/index.md).
+Developer documentation [is available in the "docs" directory](docs/en/index.md).
 
 ## Versioning
 


### PR DESCRIPTION
Current link (/docs/index.md) to dev docs gives a 404. Updated the link to (/docs/en/index.md)