### PR TITLE
FIX Resource field and filter labels are now used for GridField CRUD operations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,8 @@
 <ruleset name="SilverStripe">
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-    <!-- base rules are PSR-2 -->
-    <rule ref="PSR2" >
+    <!-- base rules are PSR-12 -->
+    <rule ref="PSR12" >
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
     </rule>

--- a/src/Model/ResourceField.php
+++ b/src/Model/ResourceField.php
@@ -110,4 +110,14 @@ class ResourceField extends DataObject
         });
         return parent::getCMSFields();
     }
+
+    /**
+     * Use the readable label for GridField CRUD operation result messages
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->ReadableLabel;
+    }
 }

--- a/src/Model/ResourceFilter.php
+++ b/src/Model/ResourceFilter.php
@@ -182,4 +182,14 @@ class ResourceFilter extends DataObject
             . '</span>'
         );
     }
+
+    /**
+     * Use the filter label for GridField CRUD operation result messages
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->FilterLabel;
+    }
 }

--- a/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
+++ b/tests/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
@@ -113,7 +113,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
         // Build the gridfield and component
         $config = GridFieldConfig::create();
-        $detailForm = new GridFieldDetailForm;
+        $detailForm = new GridFieldDetailForm();
         $config->addComponent($detailForm->setItemRequestClass(ResourceFieldItemRequest::class));
         $gridField = new GridField('Test', 'Test', $resource->Fields(), $config);
         $formMock = $this->createMock(Form::class);
@@ -138,8 +138,8 @@ class ResourceFieldItemRequestTest extends SapphireTest
 
     protected function assertArrayEqualsInOrder($expected, $actual)
     {
-        $message = 'Failed asserting array in order. Expected '.print_r($expected, true).
-            '. Actual: '.print_r($actual, true);
+        $message = 'Failed asserting array in order. Expected ' . print_r($expected, true) .
+            '. Actual: ' . print_r($actual, true);
 
         foreach ($actual as $key => $value) {
             $expectedKey = key($expected);

--- a/tests/Forms/PresentedOptionsFieldTest.php
+++ b/tests/Forms/PresentedOptionsFieldTest.php
@@ -10,7 +10,7 @@ class PresentedOptionsFieldTest extends SapphireTest
 {
     public function testConstruct()
     {
-        $field = new PresentedOptionsField('my-field', new Resource);
+        $field = new PresentedOptionsField('my-field', new Resource());
         $this->assertTrue(
             $field->hasClass('ckan-presented-options__container'),
             'Necessary class name for React binding is missing'

--- a/tests/Model/ResourceFieldTest.php
+++ b/tests/Model/ResourceFieldTest.php
@@ -12,7 +12,8 @@ class ResourceFieldTest extends SapphireTest
 
     public function testDisplayConditionsAreRenderedAsResultConditionsField()
     {
-        $fields = (new ResourceField)->getCMSFields();
+        $field = new ResourceField();
+        $fields = $field->getCMSFields();
 
         $field = $fields->dataFieldByName('DisplayConditions');
         $this->assertNotNull($field, 'DisplayConditions field was not scaffolded');
@@ -21,5 +22,12 @@ class ResourceFieldTest extends SapphireTest
             $field,
             'DisplayConditions should be rendered as a ResultConditionsField'
         );
+    }
+
+    public function testTitleShouldBeFilterLabel()
+    {
+        $field = new ResourceField();
+        $field->ReadableLabel = 'My field name';
+        $this->assertSame('My field name', $field->getTitle());
     }
 }

--- a/tests/Model/ResourceFilterTest.php
+++ b/tests/Model/ResourceFilterTest.php
@@ -83,4 +83,11 @@ class ResourceFilterTest extends SapphireTest
 
         $this->assertTrue($filter->AllColumns, 'AllColumns should be enabled by default');
     }
+
+    public function testTitleShouldBeFilterLabel()
+    {
+        $field = new ResourceFilter();
+        $field->FilterLabel = 'My filter name';
+        $this->assertSame('My filter name', $field->getTitle());
+    }
 }


### PR DESCRIPTION
And also use PSR-12 instead of PSR-2

Fixes #199