### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0",
         "silverstripe/cms": "^4.4",
         "silverstripe/admin": "^1.4",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219