### PR TITLE
DEP Use guzzle ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.3",
         "silverstripe/cms": "^4.4",
         "silverstripe/admin": "^1.4",
         "silverstripe/vendor-plugin": "^1",

--- a/tests/behat/features/ckan.feature
+++ b/tests/behat/features/ckan.feature
@@ -41,4 +41,5 @@ Feature: Use CKAN
     And I should see "Telephone"
     And I should see "Search"
     When I click on the ".griddle-table-heading-cell:nth-of-type(2)" element
-    Then I should see "Abbotsford School"
+    And I wait for 2 seconds
+    Then I should see "Albury School"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10253

ckan has a behat test that does a live guzzle request to validate this is working

If you'd like to manually test, first ensure that you have at least guzzle 7.3.0 installed `composer show | grep guzzle`, create a ckan page, and put in a data source url of https://catalogue.data.govt.nz/dataset/directory-of-educational-institutions
