### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailForm/ResourceFieldItemRequestTest.php
@@ -123,6 +123,7 @@ class ResourceFieldItemRequestTest extends SapphireTest
         $controllerMock = $this->createMock(Controller::class);
         $controllerMock->method('Link')->willReturn('test');
         $controllerMock->method('getRequest')->willReturn($request);
+        $controllerMock->method('getResponse')->willReturn(new HTTPResponse('test'));
 
         // Create an item request
         $itemRequest = new ResourceFieldItemRequest(


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/162

Replaces https://github.com/silverstripe/silverstripe-framework/pull/11075

Fixes https://github.com/silverstripe/silverstripe-ckan-registry/actions/runs/7019350079/job/19122212114#step:12:71

```
1) SilverStripe\CKANRegistry\Tests\Forms\GridField\GridFieldDetailForm\ResourceFieldItemRequestTest::testSortingOnResourceSave
Error: Call to a member function addHeader() on null
```

Debugging this locally, the controller being returned was a Mock_Controller

Broke as a result of https://github.com/silverstripe/silverstripe-framework/commit/d883719c16075412640e623557a2df4275965de1#diff-a78442d492fa67baadddeeb396bbdbf9f9ff98f000848292eee8ab99c73aaf09R723


